### PR TITLE
Pull request: Fix file handle leak in RequestCore

### DIFF
--- a/lib/requestcore/requestcore.class.php
+++ b/lib/requestcore/requestcore.class.php
@@ -252,6 +252,17 @@ class RequestCore
 		return $this;
 	}
 
+	public function __destruct() {
+		if (isset($this->read_stream)) {
+			fclose($this->read_stream);
+			unset($this->read_stream);
+		}
+		if (isset($this->write_stream)) {
+			fclose($this->write_stream);
+			unset($this->write_stream);
+		}
+	}
+
 
 	/*%******************************************************************************************%*/
 	// REQUEST METHODS
@@ -474,7 +485,6 @@ class RequestCore
 	public function set_read_file($location)
 	{
 		$this->read_file = $location;
-		// @todo: Close this connection!
 		$read_file_handle = fopen($location, 'r');
 
 		return $this->set_read_stream($read_file_handle);


### PR DESCRIPTION
We're using the PHP SDK to push a large set of files to Amazon S3.  We've found that RequestCore will open files with fopen() but will never close them with fclose().  In fact, there was a "todo" message in requestcore.php about that!

I've added a destructor to the RequestCore class which will automatically close the open file handle(s) whenever a request object is destroyed.  This may not be the _best_ approach but it does seem to work for our use case.

Would you be interested in pulling this into the SDK?  Or should I contact the RequestCore author instead?

I'm happy to sign the Amazon contributor license agreement, but I couldn't find a copy online.  If you need me to sign it, could you send me a copy?

Thanks,

Ryan Park
Head of Operations & IT, PBworks
