### PR TITLE
CFRuntime::authenticate() - $opt['curlopts'] validation

### DIFF
--- a/sdk.class.php
+++ b/sdk.class.php
@@ -893,7 +893,7 @@ class CFRuntime
 		$curlopts = array();
 
 		// Set custom CURLOPT settings
-		if (isset($opt['curlopts']))
+		if (isset($opt['curlopts']) && is_array($opt))
 		{
 			$curlopts = $opt['curlopts'];
 			unset($opt['curlopts']);

--- a/sdk.class.php
+++ b/sdk.class.php
@@ -893,7 +893,7 @@ class CFRuntime
 		$curlopts = array();
 
 		// Set custom CURLOPT settings
-		if (isset($opt['curlopts']) && is_array($opt))
+		if (is_array($opt) && isset($opt['curlopts']))
 		{
 			$curlopts = $opt['curlopts'];
 			unset($opt['curlopts']);


### PR DESCRIPTION
Hi,

Ran into this error when using methods like AmazonIAM::list_access_keys():

PHP Fatal error:  Cannot unset string offsets in /usr/lib/php/aws/1.2.6/sdk.class.php on line 899

Thanks,
David
