### PR TITLE
Fix OriginAccessIdenty for update_config_xml() method

### DIFF
--- a/services/cloudfront.class.php
+++ b/services/cloudfront.class.php
@@ -545,11 +545,11 @@ class AmazonCloudFront extends CFRuntime
 			// origin access identity
 			if (isset($opt['OriginAccessIdentity']))
 			{
-				$update->addChild('OriginAccessIdentity', 'origin-access-identity/cloudfront/' . $opt['OriginAccessIdentity']);
+                $origin->addChild('OriginAccessIdentity', 'origin-access-identity/cloudfront/' . $opt['OriginAccessIdentity']);
 			}
 			elseif (isset($xml->OriginAccessIdentity))
 			{
-				$update->addChild('OriginAccessIdentity', $xml->OriginAccessIdentity);
+				$origin->addChild('OriginAccessIdentity', $xml->OriginAccessIdentity);
 			}
 		}
 		elseif (isset($xml->CustomOrigin))


### PR DESCRIPTION
This fix setting the OriginAccessIdentity on CloudFront, it took me few hours to notice that the XML posted was wrong, others also reported the same problem here: https://forums.aws.amazon.com/thread.jspa?threadID=60989
