### PR TITLE
Add version number back to CHANGELOG.md for consistency.

### DIFF
--- a/_docs/CHANGELOG.md
+++ b/_docs/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog: "Nero"
+# Changelog: 1.3.4 "Nero"
 
 Launched Tuesday, June 7, 2011
 


### PR DESCRIPTION
I maintain an integration of AWS SDK for PHP with a PHP CMS (Drupal) and it used the changelog to detect the version of the library you were running (since that is how most libraries are setup). I had a bug report with 1.3.4 not be detected.

I have changed the code to use sdk.class.php and search for the constant, but still seems like it should be fixed. Very minor.
