### PR TITLE
fixed missing ".InstanceId" suffix on API call when using method register_instances_with_load_balancer

### DIFF
--- a/utilities/complextype.class.php
+++ b/utilities/complextype.class.php
@@ -107,6 +107,7 @@ class CFComplexType
 				}
 				else
 				{
+					$key .= '.InstanceId';
 					$out[$key] = $v;
 				}
 


### PR DESCRIPTION
fixed missing ".InstanceId" suffix on API call when using method register_instances_with_load_balancer causing the API to answer with "Unexpected complex element termination"
