### PR TITLE
Fixed error setting and retaining OriginAccessIdentity in update_config_x

### DIFF
--- a/services/cloudfront.class.php
+++ b/services/cloudfront.class.php
@@ -542,7 +542,7 @@ class AmazonCloudFront extends CFRuntime
 			$origin = $update->addChild('S3Origin');
 			$origin->addChild('DNSName', $xml->S3Origin->DNSName);
 
-      			// origin access identity
+			// origin access identity
 			if (isset($opt['OriginAccessIdentity']))
 			{
 				$origin->addChild('OriginAccessIdentity', 'origin-access-identity/cloudfront/' . $opt['OriginAccessIdentity']);

--- a/services/cloudfront.class.php
+++ b/services/cloudfront.class.php
@@ -542,14 +542,14 @@ class AmazonCloudFront extends CFRuntime
 			$origin = $update->addChild('S3Origin');
 			$origin->addChild('DNSName', $xml->S3Origin->DNSName);
 
-			// origin access identity
+      			// origin access identity
 			if (isset($opt['OriginAccessIdentity']))
 			{
-				$update->addChild('OriginAccessIdentity', 'origin-access-identity/cloudfront/' . $opt['OriginAccessIdentity']);
+				$origin->addChild('OriginAccessIdentity', 'origin-access-identity/cloudfront/' . $opt['OriginAccessIdentity']);
 			}
-			elseif (isset($xml->OriginAccessIdentity))
+			elseif (isset($xml->S3Origin->OriginAccessIdentity))
 			{
-				$update->addChild('OriginAccessIdentity', $xml->OriginAccessIdentity);
+				$origin->addChild('OriginAccessIdentity', $xml->S3Origin->OriginAccessIdentity);
 			}
 		}
 		elseif (isset($xml->CustomOrigin))


### PR DESCRIPTION
Fixed error setting and retaining OriginAccessIdentity in update_config_xml, was inserting to wrong point in XML, should be under S3Origin and not in the root of the body.

Issue as reported here: https://forums.aws.amazon.com/thread.jspa?threadID=60989
