### PR TITLE
Document the configuration keys and meanings

### DIFF
--- a/config-sample.inc.php
+++ b/config-sample.inc.php
@@ -43,6 +43,20 @@
 
 ###################################################################################################*/
 
+/*
+key
+secret_key
+account_id
+canonical_id
+canonical_name
+certificate_authority
+default_cache_config
+mfa_serial
+cloudfront_keypair_id
+cloudfront_private_key_pem
+enable_extensions
+*/
+
 
 /**
  * Create a list of credential sets that can be used with the SDK.


### PR DESCRIPTION
In releases < 1.5 all the configuration options and their defaults are clearly documented in config-sample.inc.php. As of 1.5 that is no longer the case with the new configuration management system.

There are 11 keys in 1.4 which are as follows (had aws_ in from of them and in all caps).

```
key
secret_key
account_id
canonical_id
canonical_name
certificate_authority
default_cache_config
mfa_serial
cloudfront_keypair_id
cloudfront_private_key_pem
enable_extensions
```

It would be handy to document the new names for both upgrade purposes and documentation going forward. From the examples at https://gist.github.com/1478912 a few other keys are shown and some have been changed like secret_key => secret.

Maybe I just missed the documentation, but I looked through all the classes and documentation I could find and was unable to locate any. If it does it exist it might be helpful to make it more clear where to find it. The code on this pull request is bogus, but I do not see anywhere else to submit an issue without code. I maintain the Drupal (http://drupal.org/project/awssdk) integration, but cannot complete my upgrade integration without, which include a UI for configuration, without a list of all the keys.

Thanks in advance.
