### PR TITLE
json->xml is blocked by & character

### DIFF
--- a/utilities/json.class.php
+++ b/utilities/json.class.php
@@ -98,7 +98,7 @@ class CFJSON
 			}
 			else
 			{
-				$xml->addChild($k, $v);
+				$xml->addChild($k, strtr($v, array("&" => "&amp;")));
 			}
 		}
 	}


### PR DESCRIPTION
When converting json to xml, ampersands confuse the simple xml parser and need to be escaped.
