### PR TITLE
Fixing Issue with set_distribution_config

### DIFF
--- a/services/cloudfront.class.php
+++ b/services/cloudfront.class.php
@@ -520,6 +520,12 @@ class AmazonCloudFront extends CFRuntime
 			$origin = $update->addChild('CustomOrigin');
 			$origin->addChild('DNSName', $xml->CustomOrigin->DNSName);
 
+			// Copy OriginProtocolPolicy for update
+			if ( isset($xml->CustomOrigin->OriginProtocolPolicy) )
+			{
+				$origin->addChild('OriginProtocolPolicy', $xml->CustomOrigin->OriginProtocolPolicy);
+			}
+
 			// origin access identity
 			if (isset($opt['OriginAccessIdentity']))
 			{


### PR DESCRIPTION
When trying to Enable/Disable AWS via set_distribution_config getting the following error:
"1 validation error detected: Value null at 'distributionConfig.customOrigin.originProtocolPolicy' failed to satisfy constraint: Member must not be null"
This addition fixes the issue.
