### PR TITLE
Adds the following utility methods to simplexml.class.php

### DIFF
--- a/utilities/simplexml.class.php
+++ b/utilities/simplexml.class.php
@@ -232,17 +232,17 @@ class CFSimpleXML extends SimpleXMLIterator
    */
   public function starts_with($value)
   {
-    return $this->matches(sprintf('@^%s@', $value));
+    return $this->matches(sprintf('@^%s@u', $value));
   }
 
   /**
-   * Whether or not the current node ends with the compared value.
+   * Whether or not the current node ends with the compared value..
    *
    * @param string $value (Required) The value to compare the current node to.
    * @return boolean Whether or not the current node ends with the compared value.
    */
   public function ends_with($value)
   {
-    return $this->matches(sprintf('@%s$@', $value));
+    return $this->matches(sprintf('@%s$@u', $value));
   }
 }

--- a/utilities/simplexml.class.php
+++ b/utilities/simplexml.class.php
@@ -212,4 +212,37 @@ class CFSimpleXML extends SimpleXMLIterator
 	{
 		return (stripos((string) $this, $value) !== false);
 	}
+
+  /**
+   * Whether or not the current node matches the comparisons pattern
+   *
+   * @param string $pattern (Required) The pattern to match the current node against
+   * @return boolean Whether or not the current node matches the pattern.
+   */
+  public function matches($pattern)
+  {
+    return (bool) preg_match($pattern, (string) $this);
+  }
+
+  /**
+   * Whether or not the current node starts with the compared value.
+   *
+   * @param string $value (Required) The value to compare the current node to.
+   * @return boolean Whether or not the current node starts with the compared value.
+   */
+  public function starts_with($value)
+  {
+    return $this->matches(sprintf('@^%s@', $value));
+  }
+
+  /**
+   * Whether or not the current node ends with the compared value.
+   *
+   * @param string $value (Required) The value to compare the current node to.
+   * @return boolean Whether or not the current node ends with the compared value.
+   */
+  public function ends_with($value)
+  {
+    return $this->matches(sprintf('@%s$@', $value));
+  }
 }

--- a/utilities/simplexml.class.php
+++ b/utilities/simplexml.class.php
@@ -232,7 +232,7 @@ class CFSimpleXML extends SimpleXMLIterator
    */
   public function starts_with($value)
   {
-    return $this->matches(sprintf('@^%s@u', $value));
+    return $this->matches("@^$value@u");
   }
 
   /**
@@ -243,6 +243,6 @@ class CFSimpleXML extends SimpleXMLIterator
    */
   public function ends_with($value)
   {
-    return $this->matches(sprintf('@%s$@u', $value));
+    return $this->matches("@$value$@u");
   }
 }


### PR DESCRIPTION
- matches: allows you to provide a pattern (preg) to match the current node against.
- starts_with: determines whether the current node starts with a given value.
- ends_with: determines whether the current node ends with a given value.

Simple additions; however, makes a lot of code that uses the SDK much more concise and fluent. For example, the is now possible:

$object->Key->ends_with('/');
