### PR TITLE
Correct the "Bottom line" minimum requirements check

### DIFF
--- a/_compatibility_test/sdk_compatibility_test_cli.php
+++ b/_compatibility_test/sdk_compatibility_test_cli.php
@@ -201,7 +201,7 @@ if ($php_ok && $int64_ok && $curl_ok && $simplexml_ok && $dom_ok && $spl_ok && $
 	echo "    )" . PHP_EOL;
 	echo "));" . PHP_EOL;
 }
-elseif ($php_ok && $curl_ok && $simplexml_ok && $spl_ok && $json_ok && $pcre_ok && $file_ok)
+elseif ($php_ok && $curl_ok && $simplexml_ok && $dom_ok && $spl_ok && $json_ok && $pcre_ok && $file_ok)
 {
 	echo success('Bottom Line: Yes, you can!') . PHP_EOL;
 	echo PHP_EOL;

--- a/_compatibility_test/sdk_compatibility_test_cli.php
+++ b/_compatibility_test/sdk_compatibility_test_cli.php
@@ -201,7 +201,7 @@ if ($php_ok && $int64_ok && $curl_ok && $simplexml_ok && $dom_ok && $spl_ok && $
 	echo "    )" . PHP_EOL;
 	echo "));" . PHP_EOL;
 }
-elseif ($php_ok && $curl_ok && $simplexml_ok && $dom_ok && $spl_ok && $json_ok && $pcre_ok && ($apc_ok || $xcache_ok || $sqlite_ok))
+elseif ($php_ok && $curl_ok && $simplexml_ok && $spl_ok && $json_ok && $pcre_ok && $file_ok)
 {
 	echo success('Bottom Line: Yes, you can!') . PHP_EOL;
 	echo PHP_EOL;


### PR DESCRIPTION
I received a bug report which demonstrated that the _cli.php compatibility test can return conflicting results as the conditions used to check for the minimum requirements being satisfied are different.

The conflicting results are shown http://drupal.org/node/1429614#comment-5593470.

The change should make them patch up in the same way they are in the web script.
