### PR TITLE
Stop search engines from indexing test suite results

### DIFF
--- a/_compatibility_test/sdk_compatibility_test.php
+++ b/_compatibility_test/sdk_compatibility_test.php
@@ -321,7 +321,7 @@ header('Content-type: text/html; charset=UTF-8');
 <html lang="en">
 <head>
 <title>AWS SDK for PHP: Environment Compatibility Test</title>
-
+<meta name="ROBOTS" content="NOINDEX,NOFOLLOW,NOARCHIVE" />
 <script type="text/javascript" charset="utf-8">
 /*!
   * Reqwest! A x-browser general purpose XHR connection manager

--- a/_compatibility_test/sdk_compatibility_test_cli.php
+++ b/_compatibility_test/sdk_compatibility_test_cli.php
@@ -1,6 +1,11 @@
 #! /usr/bin/env php
 <?php
-
+//Prevent script from being called via browser
+if (isset($_SERVER['HTTP_HOST']))
+{
+	header("HTTP/1.0 404 Not Found");
+	die("This script is meant to be run via the commandline.");
+}
 // Required
 $php_ok = (function_exists('version_compare') && version_compare(phpversion(), '5.2.0', '>='));
 $simplexml_ok = extension_loaded('simplexml');


### PR DESCRIPTION
Following PHP's example in 5.2.1 to phpinfo (http://php.net/ChangeLog-5.php#5.2.1), I added a noindex command (identical to the one used in phpinfo) to prevent the web-based version from being indexed. I also made an adjustment to sdk_compatibility_test_cli.php to prevent it from being accessed via a web-interface (it sends a 404 and suitable message.)

The goal is to cut down on the exposure demonstrated in this search: https://www.google.com/search?q=%22PHP+Environment+Compatibility+Test%22
