### PR TITLE
s3 class  get_object_url method  with PUT method and a specific content-type 

### DIFF
--- a/services/s3.class.php
+++ b/services/s3.class.php
@@ -842,6 +842,13 @@ class AmazonS3 extends CFRuntime
 				(strtolower($header_key) === 'expires' && isset($opt['preauth']) && (integer) $opt['preauth'] > 0)
 			)
 			{
+				// Begin
+				if ( strtolower($header_key) === 'content-type' && isset($opt['preauth']) && isset($opt['content-type']))
+                                {
+                                    $header_value = $opt['content-type'];
+                                }
+                                // End of change
+                                
 				$string_to_sign .= $header_value . "\n";
 			}
 			elseif (substr(strtolower($header_key), 0, 6) === 'x-amz-')


### PR DESCRIPTION
This code fix the issue when you make a get_object_url with PUT method  and you want to specify the content-type.

Without this code the url is signed with an empty content-type, so when make a request with a specific content-type header and the signed url that you got, you will get a "signature doesn't match" error in the response.
With this little fix you have a chance to pass a content-type in the $opt array param of get_objet_url method in order to pre-sing the url with a specific content-type.
