### PR TITLE
Get the error code from the response

### DIFF
--- a/lib/requestcore/requestcore.class.php
+++ b/lib/requestcore/requestcore.class.php
@@ -1021,6 +1021,22 @@ class ResponseCore
 
 		return $this->status === $codes;
 	}
+	
+	/**
+	 * Get the error code from the response.
+	 * @see http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/ErrorHandling.html
+	 *
+	 * @return mixed false if no error else String of error code
+	 */
+	public function getErrorCode()
+	{
+		if (!empty($this->body->__type))
+		{
+			$code = explode('#',$this->body->__type,2);
+			return (isset($code[1]))?$code[1]:false;
+		}
+		else return false;
+	}
 }
 
 class cURL_Exception extends Exception {}


### PR DESCRIPTION
It is helpful to be able to get at the error code if request is not OK.  Parse out error code strings per http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/ErrorHandling.html
