### PR TITLE
Encode ampersands in keys passed to delete_objects()

### DIFF
--- a/services/s3.class.php
+++ b/services/s3.class.php
@@ -1548,7 +1548,8 @@ class AmazonS3 extends CFRuntime
 		foreach ($opt['objects'] as $object)
 		{
 			$xobject = $xml->addChild('Object');
-			$xobject->addChild('Key', $object['key']);
+			$node = $xobject->addChild('Key');
+			$node[0] = $object['key'];
 
 			if (isset($object['version_id']))
 			{


### PR DESCRIPTION
SimpleXMLElement addChild($key, $val) doesn't encode ampersands in $val, so any keys with ampersands won't be deleted. Using the assignment method from http://us.php.net/manual/en/simplexmlelement.addchild.php#107409 fixes this.
