### PR TITLE
Change auto home detection for windows

### DIFF
--- a/sdk.class.php
+++ b/sdk.class.php
@@ -1405,10 +1405,18 @@ else
 	}
 	elseif (!isset($_ENV['HOME']) && !isset($_SERVER['HOME']))
 	{
-		$_ENV['HOME'] = `cd ~ && pwd`;
+		$os = strtolower(PHP_OS);
+		if (in_array($os, array('windows', 'winnt', 'win32')))
+		{
+			$_ENV['HOME'] = false;
+		}
+		else
+		{
+			$_ENV['HOME'] = `cd ~ && pwd`;
+		}
 		if (!$_ENV['HOME'])
 		{
-			switch (strtolower(PHP_OS))
+			switch ($os)
 			{
 				case 'darwin':
 					$_ENV['HOME'] = '/Users/' . get_current_user();


### PR DESCRIPTION
If including the sdk without a config.inc.php, there is some auto detection of home directories.

Running `cd ~ && pwd` on Windows though doesn't work and outputs "The system cannot find the path specified."
