### PR TITLE
Revert back to numeric versions

### DIFF
--- a/sdk.class.php
+++ b/sdk.class.php
@@ -115,7 +115,7 @@ function __aws_sdk_ua_callback()
 // INTERMEDIARY CONSTANTS
 
 define('CFRUNTIME_NAME', 'aws-sdk-php');
-define('CFRUNTIME_VERSION', 'Gershwin');
+define('CFRUNTIME_VERSION', '1.5.6');
 define('CFRUNTIME_BUILD', '20120515180000');
 define('CFRUNTIME_USERAGENT', CFRUNTIME_NAME . '/' . CFRUNTIME_VERSION . ' PHP/' . PHP_VERSION . ' ' . str_replace(' ', '_', php_uname('s')) . '/' . str_replace(' ', '_', php_uname('r')) . ' Arch/' . php_uname('m') . ' SAPI/' . php_sapi_name() . ' Integer/' . PHP_INT_MAX . ' Build/' . CFRUNTIME_BUILD . __aws_sdk_ua_callback());
 


### PR DESCRIPTION
I am not sure of the reason behind the change from numeric to string version in the CFRUNTIME_VERSION constant (https://github.com/amazonwebservices/aws-sdk-for-php/commit/846506794c96a9fc8da3b4d5b03a3c75bffbe489#L3R118). Currently we detect the constant and use version_compare (http://php.net/version_compare) to compare against the minimum version supported by the integration code. It looks like the number still exists in the XML with could be parse and used instead, but that is definitely more work.

I would like to hear some thoughts on this or perhaps it was an accident?
