### PR TITLE
change_content_type() doesn't update the Content-type.

### DIFF
--- a/services/s3.class.php
+++ b/services/s3.class.php
@@ -2324,7 +2324,7 @@ class AmazonS3 extends CFRuntime
 			'headers' => array(
 				'Content-Type' => $contentType
 			),
-			'metadataDirective' => 'COPY'
+			'metadataDirective' => 'REPLACE'
 		), $opt);
 
 		return $this->copy_object(


### PR DESCRIPTION
From the proposal (http://doc.s3.amazonaws.com/proposals/copy.html):

COPY: Copy the metadata from the original object. If this is specified,
      any metadata in this request will be ignored. This is the default.
REPLACE: Ignore the original object’s metadata and replace it with the
         metadata in this request.

With metadataDirective = REPLACE it works.
