### PR TITLE
prevent notice for unfound keys on s3

### DIFF
--- a/services/s3.class.php
+++ b/services/s3.class.php
@@ -1795,15 +1795,20 @@ class AmazonS3 extends CFRuntime
 
 		// Retrieve the original metadata
 		$metadata = $this->get_object_metadata($bucket, $filename);
-		if ($metadata && isset($metadata['ACL']))
+		// response failed, thus no $filename found on $bucket
+		if (!is_array($metadata) === false) {
+			return;
+		}
+
+		if (isset($metadata['ACL']))
 		{
 			$opt['acl'] = isset($opt['acl']) ? $opt['acl'] : $metadata['ACL'];
 		}
-		if ($metadata && isset($metadata['StorageClass']))
+		if (isset($metadata['StorageClass']))
 		{
 			$opt['headers']['x-amz-storage-class'] = $metadata['StorageClass'];
 		}
-		if ($metadata && isset($metadata['ContentType']))
+		if (isset($metadata['ContentType']))
 		{
 			$opt['headers']['Content-Type'] = $metadata['ContentType'];
 		}

--- a/services/s3.class.php
+++ b/services/s3.class.php
@@ -2304,7 +2304,11 @@ class AmazonS3 extends CFRuntime
 		}
 
 		$object = $this->get_object_headers($bucket, $filename);
-		$filesize = (integer) $object->header['content-length'];
+		if ($object->isOK()) {
+			$filesize = (integer) $object->header['content-length'];
+		} else {
+			$filesize = 0;
+		}
 
 		if ($friendly_format)
 		{


### PR DESCRIPTION
Very simple preventing of notices.. By checking the object->isOk() before directly accessing the header[content-length] of the result... 
