### PR TITLE
Optimization of set_time_limit() call

### DIFF
--- a/lib/requestcore/requestcore.class.php
+++ b/lib/requestcore/requestcore.class.php
@@ -819,7 +819,10 @@ class RequestCore
 	 */
 	public function send_request($parse = false)
 	{
-		set_time_limit(0);
+		if (strpos(ini_get('disable_functions'), 'set_time_limit') === false)
+		{
+			set_time_limit(0);
+		}
 
 		$curl_handle = $this->prep_request();
 		$this->response = curl_exec($curl_handle);
@@ -852,7 +855,10 @@ class RequestCore
 	 */
 	public function send_multi_request($handles, $opt = null)
 	{
-		set_time_limit(0);
+		if (strpos(ini_get('disable_functions'), 'set_time_limit') === false)
+		{
+			set_time_limit(0);
+		}
 
 		// Skip everything if there are no handles to process.
 		if (count($handles) === 0) return array();


### PR DESCRIPTION
When the "set_time_limit()" function is disabled, the call of this function creates an error like this: "set_time_limit() has been disabled for security reasons"

This function is often disabled by hosters who offer shared hosting, also some current PAAS hosters, like PHPFog/AppFog (see http://docs.phpfog.com/faqs/#sharedvdedicated).

I added a check of the 'disable_functions' configuration setting before the call.
