### PR TITLE
Bug fix for the NULL byte bug fix in version 1.5.7

### DIFF
--- a/extensions/dynamodbsessionhandler.class.php
+++ b/extensions/dynamodbsessionhandler.class.php
@@ -308,6 +308,22 @@ class DynamoDBSessionHandler
 				if ($item['expires'] > time())
 				{
 					$result = $item['data'];
+                                        
+                                        // The PHP serialization also contains NULL bytes in some cases.
+                                        // If so, the response is encoded as a JSON string with the
+                                        // prefix "json_encoded::" (fix for a bug, see 
+					// https://forums.aws.amazon.com/thread.jspa?threadID=94935)
+                                        //
+                                        // This special response format is neither handeled globally
+					// nor in this case.
+					//
+                                        // The follwoing code fixes this - but this is only temporary,
+                                        // because the global modification of contents with NULL bytes
+					// should also be removed globally...
+                                        if (strpos($result, 'json_encoded::') === 0)
+                                        {
+                                            $result = json_decode(substr($result, 14));
+                                        }
 				}
 				else
 				{


### PR DESCRIPTION
Some time ago, I reported a bug with the NULL byte handling in DynamoDB, which specially occurs when saving session data (see https://forums.aws.amazon.com/thread.jspa?threadID=94935).

Now I had the time to check the bug fix and it doesn't work. Contents with NULL bytes are now JSON encoded and can be saved now (with the prefix "json_encoded:"), but the response isn't decoded... So the session data still cannot be deserialized correctly and the sessions are invalid.

My change fixes this problem for the session handler, but the decoding of the response should be done globally, because the encoding for contents with NULL bytes is also done globally.

BTW: The test for this bug also doesn't cover the decoding of the content.
