### PR TITLE
Fallback for config will work correctly when having to determine the HOME directory.

### DIFF
--- a/sdk.class.php
+++ b/sdk.class.php
@@ -1525,7 +1525,7 @@ else
 		}
 		else
 		{
-			$_ENV['HOME'] = `cd ~ && pwd`;
+			$_ENV['HOME'] = trim(`cd ~ && pwd`);
 		}
 
 		if (!$_ENV['HOME'])
@@ -1549,8 +1549,8 @@ else
 		}
 	}
 
-	if (getenv('HOME') && file_exists(getenv('HOME') . DIRECTORY_SEPARATOR . '.aws' . DIRECTORY_SEPARATOR . 'sdk' . DIRECTORY_SEPARATOR . 'config.inc.php'))
+	if (!!$_ENV['HOME'] && file_exists($_ENV['HOME'] . DIRECTORY_SEPARATOR . '.aws' . DIRECTORY_SEPARATOR . 'sdk' . DIRECTORY_SEPARATOR . 'config.inc.php'))
 	{
-		include_once getenv('HOME') . DIRECTORY_SEPARATOR . '.aws' . DIRECTORY_SEPARATOR . 'sdk' . DIRECTORY_SEPARATOR . 'config.inc.php';
+		include_once $_ENV['HOME'] . DIRECTORY_SEPARATOR . '.aws' . DIRECTORY_SEPARATOR . 'sdk' . DIRECTORY_SEPARATOR . 'config.inc.php';
 	}
 }


### PR DESCRIPTION
getenv() is NOT fed by changes to $_ENV, so using getenv() to load the config file will fail when the fall back is used.
