### PR TITLE
Fixed circular to string method in simplexml

### DIFF
--- a/utilities/simplexml.class.php
+++ b/utilities/simplexml.class.php
@@ -161,7 +161,7 @@ class CFSimpleXML extends SimpleXMLIterator
 	 */
 	public function to_string()
 	{
-		$s = (string) $this;
+		$s = parent::__toString($this);
 
 		if ($this->attributes())
 		{


### PR DESCRIPTION
utilities/simplexml was changed in 1.5.7 to extend simplexmlelement::_toString(), but the implemented to_string() method had an implied call _toString. 

This fix prevents the never-ending loop.
