### PR TITLE
Fixed E_NOTICE being raised by AmazonDynamoDB->attributes()

### DIFF
--- a/services/dynamodb.class.php
+++ b/services/dynamodb.class.php
@@ -445,8 +445,7 @@ class AmazonDynamoDB extends CFRuntime
 			return null;
 		}
 
-		// Create the info to return. Treat all values as strings by default
-		$info = array('value' => (string) $value, 'type' => self::TYPE_STRING);
+		$info = array();
 
 		// Handle boolean values
 		if (is_bool($value))
@@ -458,6 +457,7 @@ class AmazonDynamoDB extends CFRuntime
 		elseif (is_int($value) || is_float($value))
 		{
 			$info['type'] = self::TYPE_NUMBER;
+			$info['value'] = (string)$value;
 		}
 		// Handle arrays
 		elseif (is_array($value))
@@ -493,6 +493,11 @@ class AmazonDynamoDB extends CFRuntime
 
 			// Make sure the type is changed to be the appropriate array/set type
 			$info['type'] = $set_type . self::SUFFIX_FOR_TYPES;
+		}
+		else 
+		{
+			$info['type']  = self::TYPE_STRING;
+			$info['value'] = (string)$value;
 		}
 
 		return $info;


### PR DESCRIPTION
AmazonDynamoDB->attributes() caused an E_NOTICE "array to string conversion" when a value was an array. The following test case fails with SDK 1.5.14 and PHP 5.4.7 (obviously with E_NOTICE level reporting) and passes with this patch.

``` php
/**
 * Description of DynamoDBTestCase
 *
 * @author jarrodswift
 */
class DynamoDBTestCase extends PHPUnit_Framework_TestCase {
    /**
     * Test fails with error (E_NOTICE level)
     */
    public function testAttributesWithSets() {
        $dynamo = new AmazonDynamoDB();

        $attributes = array(
            'stringSet' => array('one', 'two', 'three',),
            'numberSet' => array(1.0, 2.0, 3.0,),
        );

        $expected = array(
            'stringSet' => array(
                'SS' => array('one', 'two', 'three',),
            ),
            'numberSet' => array(
                'NS' => array(1.0, 2.0, 3.0,),
            ),
        );

        $this->assertEquals( $expected, $dynamo->attributes($attributes));
    }
}
```
