### PR TITLE
Fix for Dynamo SDK attempting to convert an array to a string, setting off a php notice. 

### DIFF
--- a/services/dynamodb.class.php
+++ b/services/dynamodb.class.php
@@ -446,7 +446,7 @@ class AmazonDynamoDB extends CFRuntime
 		}
 
 		// Create the info to return. Treat all values as strings by default
-		$info = array('value' => (string) $value, 'type' => self::TYPE_STRING);
+		$info = array('value' => $value, 'type' => self::TYPE_STRING);
 
 		// Handle boolean values
 		if (is_bool($value))


### PR DESCRIPTION
When attempting to persist a string set to dynamo, the SDK attempts to convert the array to a string, which isn't possible so it sets off a php notice. I can't see any reason to try and force the data type to be a string, so unless I'm missing something this seems to be more of an inconvenience than anything. Another solution would be to throw an @ sign before that line to surpress any warnings. 
