### PR TITLE
Fix bug caused by some SSL implementations with bucket names that have dots in them.

### DIFF
--- a/services/s3.class.php
+++ b/services/s3.class.php
@@ -555,9 +555,15 @@ class AmazonS3 extends CFRuntime
 			$this->temporary_prefix = true;
 		}
 
+		$bucket_name_may_cause_ssl_wildcard_failures = false;
+		if (strpos($bucket, '.') !== false)
+		{
+		    $bucket_name_may_cause_ssl_wildcard_failures = true;
+		}
+
 		// Determine hostname
 		$scheme = $this->use_ssl ? 'https://' : 'http://';
-		if ($this->resource_prefix || $this->path_style) // Use bucket-in-path method.
+		if ($bucket_name_may_cause_ssl_wildcard_failures || $this->resource_prefix || $this->path_style) // Use bucket-in-path method.
 		{
 			$hostname = $this->hostname . $this->resource_prefix . (($bucket === '' || $this->resource_prefix === '/' . $bucket) ? '' : ('/' . $bucket));
 		}


### PR DESCRIPTION
cURL, when compiled with modern versions of libssh2/OpenSSL, uses
stricter wildcard SSL CN matching.  This causes bucketnames with dots in
them to generate SSL failures like so:

  cURL error: SSL: certificate subject name '*.s3.amazonaws.com' does
  not match target host name 'sub.domain.s3.amazonaws.com' (cURL
  error code 51)

This patch causes the S3 authenticate() method to auto-detect this
situation and route around it securely by using path-style URL's for
making API calls.

Path-style URL's look like s3.amazonaws.com/[bucket-name]/key and thus
have no problem passing the strict SSL name matching algorithm.
