### PR TITLE
Revert CFRUNTIME_VERSION to be numeric.

### DIFF
--- a/sdk.class.php
+++ b/sdk.class.php
@@ -115,7 +115,7 @@ function __aws_sdk_ua_callback()
 // INTERMEDIARY CONSTANTS
 
 define('CFRUNTIME_NAME', 'aws-sdk-php');
-define('CFRUNTIME_VERSION', 'Panther');
+define('CFRUNTIME_VERSION', '1.5.15');
 define('CFRUNTIME_BUILD', '20120926163000');
 define('CFRUNTIME_USERAGENT', CFRUNTIME_NAME . '/' . CFRUNTIME_VERSION . ' PHP/' . PHP_VERSION . ' ' . str_replace(' ', '_', php_uname('s')) . '/' . str_replace(' ', '_', php_uname('r')) . ' Arch/' . php_uname('m') . ' SAPI/' . php_sapi_name() . ' Integer/' . PHP_INT_MAX . ' Build/' . CFRUNTIME_BUILD . __aws_sdk_ua_callback());
 


### PR DESCRIPTION
This happened once before only in one of the textual files that includes the version number. I have since changed my code to depend on the code constant since it is cleaner and was hoped to be a better place to count on the version, but it seems to have been accidentally changed to the release name. Let me know if I am mistaken, otherwise please fix.

Drupal issue http://drupal.org/node/1822182

Thanks.
