### PR TITLE
Incorrect sqs api version fix

### DIFF
--- a/services/sqs.class.php
+++ b/services/sqs.class.php
@@ -134,7 +134,7 @@ class AmazonSQS extends CFRuntime
 	 */
 	public function __construct(array $options = array())
 	{
-		$this->api_version = '2012-09-15';
+		$this->api_version = '2012-11-05';
 		$this->hostname = self::DEFAULT_URL;
 		$this->auth_class = 'AuthV2Query';
 


### PR DESCRIPTION
Fixed API version for SQS by setting it to the correct version: 2012-11-05

The API version for SQS was set to '2012-09-15'. This is not a valid SQS API version. The possible versions are listed here:
http://docs.amazonwebservices.com/AWSSimpleQueueService/latest/APIReference/Welcome.html

The current version is listed here:
http://aws.amazon.com/releasenotes/8545761433555407
