### PR TITLE
Update services/s3.class.php

### DIFF
--- a/services/s3.class.php
+++ b/services/s3.class.php
@@ -2376,10 +2376,11 @@ class AmazonS3 extends CFRuntime
         if ($object->isOK()) {
 		    $filesize = (integer) $object->header['content-length'];
 		} else {
-		    $filesize = 0;
+		    // If the file doesn't exist, return a value of -1	
+		    $filesize = -1;
 		}
 
-		if ($friendly_format)
+		if ($friendly_format && $filesize != -1)
 		{
 			$filesize = $this->util->size_readable($filesize);
 		}


### PR DESCRIPTION
I've changed the get_object_filesize() method.  Originally, the method gets the object.  If the object doesn't exists, it returns 0.
This is problematic in applications I've used the method in.  Getting a filesize of 0 implies that a file was written with 0 bytes (Usually indicating a failure of some kind when creating the original object, or a file that is in progress of being uploaded or created).
Instead, I propose returning -1 for an object that doesn't exist to distinguish a missing file from a 0 byte (corrupted) file.
I also added a check for filesize = -1 to the "friendly_format" if statement to bypass the size_readable method when a file doesn't exists.
