### PR TITLE
Fix proxy support header parsing problem

### DIFF
--- a/lib/requestcore/requestcore.class.php
+++ b/lib/requestcore/requestcore.class.php
@@ -791,6 +791,22 @@ class RequestCore
 		// As long as this came back as a valid resource...
 		if (is_resource($this->curl_handle))
 		{
+			if ( is_array( $this->proxy ) )
+			{
+				$proxy_response_headers = explode("\r\n\r\n", trim($this->response));
+				if ( 2 < count($proxy_response_headers) )
+				{
+					if ( 0 == strncmp( $proxy_response_headers[0], 'HTTP/', 5 )
+						&& 0 == strncmp( $proxy_response_headers[1], 'HTTP/', 5 )
+					)
+					{
+						$this->response = array_slice( $proxy_response_headers, 1, count($proxy_response_headers ) );
+						$this->response = implode( "\r\n\r\n", $this->response );
+					}
+				}
+				unset($proxy_response_headers);
+			}
+
 			// Determine what's what.
 			$header_size = curl_getinfo($this->curl_handle, CURLINFO_HEADER_SIZE);
 			$this->response_headers = substr($this->response, 0, $header_size);


### PR DESCRIPTION
As referenced here: 

https://forums.aws.amazon.com/thread.jspa?messageID=227413

This patch fixes a problem parsing the proxy header. Otherwise, the tail of the header ends up in the $body and it throws parse errors such as:

Warning: SimpleXMLElement::__construct(): Entity: line 1: parser error : Start tag expected, '<' not found in /usr/share/pear/AWSSDKforPHP/sdk.class.php on line 1275

Warning: SimpleXMLElement::__construct(): 012 22:53:43 GMT in /usr/share/pear/AWSSDKforPHP/sdk.class.php on line 1275

Warning: SimpleXMLElement::__construct(): ^ in /usr/share/pear/AWSSDKforPHP/sdk.class.php on line 1275

Fatal error: Uncaught exception 'Parser_Exception' with message 'String could not be parsed as XML' in /usr/share/pear/AWSSDKforPHP/sdk.class.php:1279
Stack trace:
#0 /usr/share/pear/AWSSDKforPHP/sdk.class.php(1048): CFRuntime->parse_callback('012 22:53:43 GM...')
#1 /usr/share/pear/AWSSDKforPHP/services/ec2.class.php(3425): CFRuntime->authenticate('DescribeVolumes', Array)
