### PR TITLE
The method "restore_archived_object" was not working because the filename was never used.

### DIFF
--- a/services/s3.class.php
+++ b/services/s3.class.php
@@ -4176,6 +4176,7 @@ class AmazonS3 extends CFRuntime
 	{
 		if (!$opt) $opt = array();
 		$opt['verb'] = 'POST';
+                $opt['resource'] = $filename;
 		$opt['sub_resource'] = 'restore';
 		$opt['headers'] = array(
 			'Content-Type' => 'application/xml'


### PR DESCRIPTION
I made a quick change on "restore_archived_object" function that allows now the use of the method.
