### PR TITLE
eliminated curl_setopt of CURLOPT_CLOSEPOLICY

### DIFF
--- a/lib/requestcore/requestcore.class.php
+++ b/lib/requestcore/requestcore.class.php
@@ -623,7 +623,6 @@ class RequestCore
 		curl_setopt($curl_handle, CURLOPT_URL, $this->request_url);
 		curl_setopt($curl_handle, CURLOPT_FILETIME, true);
 		curl_setopt($curl_handle, CURLOPT_FRESH_CONNECT, false);
-		curl_setopt($curl_handle, CURLOPT_CLOSEPOLICY, CURLCLOSEPOLICY_LEAST_RECENTLY_USED);
 		curl_setopt($curl_handle, CURLOPT_MAXREDIRS, 5);
 		curl_setopt($curl_handle, CURLOPT_HEADER, true);
 		curl_setopt($curl_handle, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
I have eliminated curl_setopt of CURLOPT_CLOSEPOLICY.
CURLOPT_CLOSEPOLICY is deprecated, as it was never implemented in cURL and never had any effect.
This parameter removed in PHP 5.6.0.
http://php.net/manual/en/function.curl-setopt.php
